### PR TITLE
fix: Correct housekeeping dashboard route

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -102,7 +102,7 @@ export const ROUTES = {
   // Housekeeping Module
   HOUSEKEEPING: {
     BASE: '/housekeeping',
-    DASHBOARD: '/housekeeping/dashboard',
+    DASHBOARD: '/housekeeping',
     TASKS: '/housekeeping/tasks',
     REPORTS: '/housekeeping/reports',
   },


### PR DESCRIPTION
 Problem Fixed:
- Changed HOUSEKEEPING.DASHBOARD from '/housekeeping/dashboard' to '/housekeeping'
- Now housekeeping dashboard is accessible at /housekeeping instead of /housekeeping/dashboard
- Maintains consistency with other modules where BASE route serves as dashboard

 Details:
- The AppRouter was correctly configured for 'housekeeping' path
- Navigation config automatically uses the updated ROUTES constants
- No breaking changes to existing functionality

 Testing:
- Build successful
- Route now resolves correctly