### PR TITLE
fix: Update API URL references to use consistent environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 VITE_MODE=admin
+# API Configuration
+VITE_API_URL=http://localhost:3000/api

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
 # Configuración para acceder al sistema administrativo
 VITE_MODE=admin
+
+# API Configuration
+# Para desarrollo local
+VITE_API_URL=http://localhost:3000/api
+
+# Para producción, cambiar por la URL real del backend
+# VITE_API_URL=https://tu-backend.vercel.app/api

--- a/src/config/environment.example
+++ b/src/config/environment.example
@@ -6,7 +6,7 @@ VITE_USE_REAL_API=false
 
 # API Base URL (only used when VITE_USE_REAL_API=true)
 # Replace with your actual API endpoint
-VITE_API_BASE_URL=http://localhost:3001/api
+VITE_API_URL=http://localhost:3000/api
 
 # Development vs Production
 NODE_ENV=development

--- a/src/modules/frontdesk/services/apiService.ts
+++ b/src/modules/frontdesk/services/apiService.ts
@@ -20,7 +20,7 @@ interface ReservationSearchResult {
 }
 
 // API Configuration
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 const API_TIMEOUT = 10000; // 10 seconds
 
 /**

--- a/src/modules/frontdesk/services/frontdeskService.ts
+++ b/src/modules/frontdesk/services/frontdeskService.ts
@@ -17,7 +17,7 @@ import {
  * Servicio de Frontdesk - Manejo de habitaciones y operaciones
  */
 export class FrontdeskService {
-  private static baseURL = '/api/frontdesk';
+  private static baseURL = '/frontdesk';
   private static isDevelopment = import.meta.env.DEV;
 
   // =================== ROOMS ===================

--- a/src/modules/reservations/lib/apiClient.ts
+++ b/src/modules/reservations/lib/apiClient.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // Create axios instance with base configuration
 export const apiClient = axios.create({
-  baseURL: '/api', // This will be replaced with actual API URL
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',

--- a/src/services/BaseApiService.ts
+++ b/src/services/BaseApiService.ts
@@ -22,7 +22,7 @@ interface ApiConfig {
 }
 
 const defaultConfig: ApiConfig = {
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api',
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
   timeout: 10000, // 10 seconds
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
This pull request updates the environment variable for the API base URL across the codebase, standardizing its name to `VITE_API_URL` and updating its default value to `http://localhost:3000/api`. This change ensures consistent API configuration in both development and production environments, and updates all references in configuration files and service modules to use the new variable.

**API Configuration Standardization:**

* Added `VITE_API_URL` to `.env` and `.env.example`, with clear documentation for local development and production usage. [[1]](diffhunk://#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dR2-R3) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR3-R9)
* Updated `src/config/environment.example` to use `VITE_API_URL` instead of `VITE_API_BASE_URL`, aligning with the new naming convention.

**Codebase Updates for API URL Usage:**

* Changed all references in service modules (`src/modules/frontdesk/services/apiService.ts`, `src/services/BaseApiService.ts`, `src/modules/reservations/lib/apiClient.ts`) to use `VITE_API_URL` and updated the default fallback to `http://localhost:3000/api`. [[1]](diffhunk://#diff-0880dd9defcb522fa20677809b4c05f342ebbd17fb4e0b001cbe35b6ab26622eL23-R23) [[2]](diffhunk://#diff-9398fee0670be1f1caa915a98906a9425686341c9ed5ea720d5628a389c3d189L25-R25) [[3]](diffhunk://#diff-016e43610920ca5ea4c90f983d3f8946c07b9c2c2e6d20dedc2c88f1b1d2cc45L5-R5)
* Updated the `baseURL` in `FrontdeskService` to remove the `/api` prefix, now using `/frontdesk` for better route handling.